### PR TITLE
Support vectors of custom objects in i/diy/mpi/collectives.hpp when t…

### DIFF
--- a/include/diy/mpi/collectives.hpp
+++ b/include/diy/mpi/collectives.hpp
@@ -26,14 +26,15 @@ namespace mpi
     static void broadcast(const communicator& comm, std::vector<T>& x, int root)
     {
 #ifndef DIY_NO_MPI
-      size_t sz = x.size();
+      size_t sz        = x.size();
+      int    elem_size = Datatype::count(x[0]);         // size of 1 vector element in units of mpi datatype
       Collectives<size_t, void*>::broadcast(comm, sz, root);
 
       if (comm.rank() != root)
           x.resize(sz);
 
       MPI_Bcast(Datatype::address(x[0]),
-                x.size(),
+                elem_size * x.size(),
                 Datatype::datatype(), root, comm);
 #endif
     }
@@ -75,15 +76,16 @@ namespace mpi
     {
 #ifndef DIY_NO_MPI
       std::vector<int>  counts(comm.size());
-      Collectives<int,void*>::gather(comm, (int) in.size(), counts, root);
+      int               elem_size = Datatype::count(in[0]);     // size of 1 vector element in units of mpi datatype
+      Collectives<int,void*>::gather(comm, (int)(elem_size * in.size()), counts, root);
 
       std::vector<int>  offsets(comm.size(), 0);
       for (unsigned i = 1; i < offsets.size(); ++i)
         offsets[i] = offsets[i-1] + counts[i-1];
 
-      std::vector<T> buffer(offsets.back() + counts.back());
+      std::vector<T> buffer((offsets.back() + counts.back()) / elem_size);
       MPI_Gatherv(Datatype::address(const_cast<T&>(in[0])),
-                  in.size(),
+                  elem_size * in.size(),
                   Datatype::datatype(),
                   Datatype::address(buffer[0]),
                   &counts[0],
@@ -95,8 +97,8 @@ namespace mpi
       size_t cur = 0;
       for (unsigned i = 0; i < (unsigned)comm.size(); ++i)
       {
-          out[i].reserve(counts[i]);
-          for (unsigned j = 0; j < (unsigned)counts[i]; ++j)
+          out[i].reserve(counts[i] / elem_size);
+          for (unsigned j = 0; j < (unsigned)(counts[i] / elem_size); ++j)
               out[i].push_back(buffer[cur++]);
       }
 #else
@@ -124,10 +126,11 @@ namespace mpi
     static void gather(const communicator& comm, const std::vector<T>& in, int root)
     {
 #ifndef DIY_NO_MPI
-      Collectives<int,void*>::gather(comm, (int) in.size(), root);
+      int elem_size = Datatype::count(in[0]);           // size of 1 vector element in units of mpi datatype
+      Collectives<int,void*>::gather(comm, (int)(elem_size * in.size()), root);
 
       MPI_Gatherv(Datatype::address(const_cast<T&>(in[0])),
-                  in.size(),
+                  elem_size * in.size(),
                   Datatype::datatype(),
                   0, 0, 0,
                   Datatype::datatype(),
@@ -159,15 +162,16 @@ namespace mpi
     {
 #ifndef DIY_NO_MPI
       std::vector<int>  counts(comm.size());
-      Collectives<int,void*>::all_gather(comm, (int) in.size(), counts);
+      int               elem_size = Datatype::count(in[0]);     // size of 1 vector element in units of mpi datatype
+      Collectives<int,void*>::all_gather(comm, (int)(elem_size * in.size()), counts);
 
       std::vector<int>  offsets(comm.size(), 0);
       for (unsigned i = 1; i < offsets.size(); ++i)
         offsets[i] = offsets[i-1] + counts[i-1];
 
-      std::vector<T> buffer(offsets.back() + counts.back());
+      std::vector<T> buffer((offsets.back() + counts.back()) / elem_size);
       MPI_Allgatherv(Datatype::address(const_cast<T&>(in[0])),
-                     in.size(),
+                     elem_size * in.size(),
                      Datatype::datatype(),
                      Datatype::address(buffer[0]),
                      &counts[0],
@@ -179,8 +183,8 @@ namespace mpi
       size_t cur = 0;
       for (int i = 0; i < comm.size(); ++i)
       {
-          out[i].reserve(counts[i]);
-          for (int j = 0; j < counts[i]; ++j)
+          out[i].reserve(counts[i] / elem_size);
+          for (int j = 0; j < (int)(counts[i] / elem_size); ++j)
               out[i].push_back(buffer[cur++]);
       }
 #else
@@ -238,9 +242,10 @@ namespace mpi
     {
 #ifndef DIY_NO_MPI
       out.resize(in.size());
+      int elem_size = Datatype::count(in[0]);               // size of 1 vector element in units of mpi datatype
       MPI_Allreduce(Datatype::address(const_cast<T&>(in[0])),
                     Datatype::address(out[0]),
-                    in.size(),
+                    elem_size * in.size(),
                     Datatype::datatype(),
                     detail::mpi_op<Op>::get(),
                     comm);
@@ -267,10 +272,13 @@ namespace mpi
     static void all_to_all(const communicator& comm, const std::vector<T>& in, std::vector<T>& out, int n = 1)
     {
 #ifndef DIY_NO_MPI
+      int elem_size = Datatype::count(in[0]);               // size of 1 vector element in units of mpi datatype
       // NB: this will fail if T is a vector
-      MPI_Alltoall(Datatype::address(const_cast<T&>(in[0])), n,
+      MPI_Alltoall(Datatype::address(const_cast<T&>(in[0])),
+                   elem_size * n,
                    Datatype::datatype(),
-                   Datatype::address(out[0]), n,
+                   Datatype::address(out[0]),
+                   elem_size * n,
                    Datatype::datatype(),
                    comm);
 #else


### PR DESCRIPTION
…he user provides a specialized mpi_datatype object for one vector element, mpi_datatype::datatype() returns an MPI datatype (e.g. MPI_BYTE) to use for the collective, and mpi_datatype::count() returns the size of one vector element in units of the MPI datatype