### PR TITLE
Changes to diy::mpi

### DIFF
--- a/include/diy/mpi.hpp
+++ b/include/diy/mpi.hpp
@@ -25,30 +25,37 @@ namespace mpi
 //! \ingroup MPI
 struct environment
 {
-  inline environment();
-  inline environment(int argc, char* argv[]);
+  inline environment(int threading = MPI_THREAD_FUNNELED);
+  inline environment(int argc, char* argv[], int threading = MPI_THREAD_FUNNELED);
   inline ~environment();
+
+  int   threading() const           { return provided_threading; }
+
+  int   provided_threading;
 };
 
 }
 }
 
 diy::mpi::environment::
-environment()
+environment(int threading)
 {
 #ifndef DIY_NO_MPI
   int argc = 0; char** argv;
-  MPI_Init(&argc, &argv);
+  MPI_Init_thread(&argc, &argv, threading, &provided_threading);
+#else
+  provided_threading = threading;
 #endif
 }
 
 diy::mpi::environment::
-environment(int argc, char* argv[])
+environment(int argc, char* argv[], int threading)
 {
 #ifndef DIY_NO_MPI
-  MPI_Init(&argc, &argv);
+  MPI_Init_thread(&argc, &argv, threading, &provided_threading);
 #else
   (void) argc; (void) argv;
+  provided_threading = threading;
 #endif
 }
 

--- a/include/diy/mpi/no-mpi.hpp
+++ b/include/diy/mpi/no-mpi.hpp
@@ -13,6 +13,12 @@ using MPI_Comm = int;
 static const MPI_Comm MPI_COMM_NULL = 0;
 static const MPI_Comm MPI_COMM_WORLD = 1;
 
+/* MPI threading modes */
+static const int MPI_THREAD_SINGLE      = 0;
+static const int MPI_THREAD_FUNNELED    = 1;
+static const int MPI_THREAD_SERIALIZED  = 2;
+static const int MPI_THREAD_MULTIPLE    = 3;
+
 /* define datatypes */
 using MPI_Datatype = size_t;
 


### PR DESCRIPTION
* Add communication.split()
* Add threading to environment, defaulting to MPI_THREAD_FUNNELED