### PR TITLE
Missing share.h include

### DIFF
--- a/include/diy/io/utils.hpp
+++ b/include/diy/io/utils.hpp
@@ -4,6 +4,7 @@
 #if defined(_WIN32)
 #include <direct.h>
 #include <io.h>
+#include <share.h>
 #else
 #include <unistd.h>     // mkstemp() on Mac
 #include <dirent.h>


### PR DESCRIPTION
This is needed at least on MinGW:
error: ‘_SH_DENYNO’ was not declared in this scope

Should also be required on msvc : https://msdn.microsoft.com/en-us/library/febdfes5.aspx